### PR TITLE
Stability fixes + support newer versions of CUDA

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -50,7 +50,7 @@ genrule(
           " -gencode=arch=compute_52,code=\\\"sm_52,compute_52\\\" " +
           " -gencode=arch=compute_61,code=\\\"sm_61,compute_61\\\" " +
           " -gencode=arch=compute_70,code=\\\"sm_70,compute_70\\\" " +
-          " -O3 -Xcompiler -Wall  -D_FORCE_INLINES  --ptxas-options=\"-v\"" +
+          " -O3 -Xcompiler -Wall --std=c++11  -D_FORCE_INLINES  --ptxas-options=\"-v\"" +
           " --compiler-options=\"-fPIC\",\"-Iexternal/cuda_local/include\"" +
           " --maxrregcount=64 -c $(location :kernel.cu) -o $@"
 )

--- a/Miner.h
+++ b/Miner.h
@@ -12,9 +12,9 @@
 #include "cuda_runtime.h"
 #include "UCPClient.h"
 
-extern cudaError_t grindNonces(uint32_t* nonceResult, uint64_t* hashStart,
-                               const uint64_t* header, int deviceIndex,
-                               int threadsPerBlock, int blockSize);
+extern cudaError_t grindNonces(uint32_t *dev_nonceStart, uint64_t* dev_header, uint32_t* dev_nonceResult,
+                               uint64_t* dev_hashStart, uint32_t *nonceResult, uint64_t *hashStart, const
+                               uint64_t *header, int deviceIndex, int threadsPerBlock, int blockSize);
 
 void startMining(UCPClient& ucpClient, const std::set<int>& deviceList,
                  int threadsPerBlock, int blockSize);

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,6 @@ git_repository(
 
 new_local_repository(
     name = "cuda_local",
-    path = "/usr/local/cuda-9.2",
+    path = "/usr/local/cuda",
     build_file = "BUILD.cuda-local",
 )


### PR DESCRIPTION
* Use `/usr/local/cuda` directory for cuda installation location. This is a symlink to the most recently installed CUDA installation, so it will support newer versions of CUDA, e.g. CUDA 10.

* Allocate GPU memory once at miner start instead of doing it continuously at every loop. This should greatly improved stability of the GPU miner (especially on Windows).